### PR TITLE
toml-support

### DIFF
--- a/production.tmpl.ini
+++ b/production.tmpl.ini
@@ -1,23 +1,8 @@
-[test_cfg]
-
-a = b
-test_ini = test2
-test_list = [
-    "test0",
-    "test1",
-    2]
-
-test_dict = {"test_key": "test_val", "test_key2": "test_val2"}
-
-test_list_dict = [
-    {"A": 1, "B": "b"},
-    {"A": 2, "B": "c"},
-    {"A": 3, "B": "d"},
-    {"A": 4, "B": "e"}]
+[project]
 
 [loggers]
 keys = root, temp
-disable_existing_loggers = false
+disable_existing_loggers = true
 
 [handlers]
 keys = console
@@ -31,7 +16,7 @@ handlers = console
 
 [logger_temp]
 level = DEBUG
-qualname = test_cfg
+qualname = temp
 handlers = console
 propagate = 0
 
@@ -39,6 +24,12 @@ propagate = 0
 class = StreamHandler
 args = (sys.stderr,)
 level = NOTSET
+formatter = generic
+
+[handler_file]
+class     = FileHandler
+args      = ('python.log', 'w')
+level     = NOTSET
 formatter = generic
 
 [formatter_generic]

--- a/production.tmpl.toml
+++ b/production.tmpl.toml
@@ -1,0 +1,39 @@
+[project]
+
+[loggers]
+keys = 'root, temp'
+
+disable_existing_loggers = true
+
+[handlers]
+keys = 'console'
+
+[formatters]
+keys = 'generic'
+
+[logger_root]
+level    = 'WARNING'
+handlers = 'console'
+
+[logger_temp]
+level     = 'DEBUG'
+qualname  = 'temp'
+handlers  = 'console'
+propagate = 0
+
+[handler_console]
+class     = 'StreamHandler'
+args      = '(sys.stderr,)'
+level     = 'NOTSET'
+formatter = 'generic'
+
+# following toml format about single-quotes in args
+[handler_file]
+class     = 'FileHandler'
+args      = '''('python.log', 'w')'''
+level     = 'NOTSET'
+formatter = 'generic'
+
+[formatter_generic]
+format  = '%(asctime)s [%(levelname)-5.5s] %(module)s#%(funcName)s@%(lineno)d: %(message)s'
+datefmt = '%Y-%m-%d %H:%M:%S'

--- a/pyutil_cfg/cfg.py
+++ b/pyutil_cfg/cfg.py
@@ -1,86 +1,221 @@
 # -*- coding: utf-8 -*-
 
-from typing import Optional, Any
-from configparser import ConfigParser
+from enum import Enum
+from typing import Optional, Any, TypedDict, NotRequired
+
+from configparser import ConfigParser, RawConfigParser
+import tomllib
 import logging
 import logging.config
 
 import json
 
 
-def init(name: str, ini_filename: str, log_ini_filename: str = '', params: Optional[dict] = None) -> tuple[logging.Logger, dict]:
-    logger = _init_logger(name, log_ini_filename, ini_filename)
-    config = _init_ini_file(name, ini_filename, logger)
-    config = _post_init_config(params, config, logger)
+class FileType(Enum):
+    ini = 1
+    toml = 2
 
-    logger.debug('pyutil_cfg.init: to return: name: %s logger: %s config: %s', name, logger, config)
+    def __str__(self):
+        return self.name
+
+
+class Loggers(TypedDict):
+    keys: str
+    disable_existing_loggers: NotRequired[bool]
+
+
+class Logger(TypedDict):
+    qualname: str
+    handlers: str
+    level: NotRequired[str]
+    propagate: NotRequired[int | bool | str]
+
+
+class Handlers(TypedDict):
+    keys: str
+
+
+Handler = TypedDict(
+    'Handler',
+    {
+        'class': str,
+        'args': NotRequired[str],
+        'level': NotRequired[str],
+        'formatter': NotRequired[str],
+    }
+)
+
+
+class Formatters(TypedDict):
+    keys: str
+
+
+Formatter = TypedDict(
+    'Formatter',
+    {
+        'format': NotRequired[str],
+        'datefmt': NotRequired[str],
+        'style': NotRequired[str],
+        'validate': NotRequired[bool | str],
+        'defaults': NotRequired[dict[str, float | int | bool | str]],
+        'class': NotRequired[str],
+    }
+)
+
+
+class Config(TypedDict):
+    loggers: NotRequired[Loggers]
+    handlers: NotRequired[Handlers]
+    formatters: NotRequired[Formatters]
+
+    '''
+    logger_*: Logger
+    '''
+
+    '''
+    handler_*: Handler
+    '''
+
+    '''
+    formatter_*: Formatter
+    '''
+
+
+def init(name: str, filename: str, log_name: str = '', log_filename: str = '', extra_params: Optional[dict] = None, is_extra_params_in_file_ok: bool = True, is_skip_extra_params_in_file: bool = False, show_config: Optional[int] = None) -> tuple[logging.Logger, Config]:
+    '''
+    init
+
+    initialize the logger and config.
+
+    Args:
+        name: name to extract in the config file and as the logger name.
+        filename: config filename. suffix with .toml or .ini
+
+        log_name: opttionally log-specific name
+        log_filename: optionally log-specific config filename.
+        extra_params: optionally extra values not defined in the config filename.
+                      usually from argparse.
+
+        is_extra_params_in_file_ok:
+            whether to raise error if extra_params already defined in the config file
+            (as programmatically rewriting the settings from config file)
+            default is ok.
+
+        is_skip_extra_params_in_file:
+            whether to skip extra if extra is in file.
+            default tih False as extra can overwrite the config in file.
+
+        show_config: log-level in the config that shows config before return.
+                     None means not showing the config.
+
+    Return:
+        logger, config
+    '''
+    if log_name == '':
+        log_name = name
+    if log_filename == '':
+        log_filename = filename
+
+    # logger
+    config_from_log_file = _config_from_file(log_filename)
+    logger = _init_logger(log_name, config_from_log_file)
+
+    # config
+    config_from_file = _config_from_file(filename)
+    config = _init_config(name, config_from_file)
+    config = _post_init_config(config, extra_params, is_extra_params_in_file_ok, is_skip_extra_params_in_file, logger)
+
+    if show_config is not None:
+        logger.log(show_config, f'pyutil_cfg.init: name: {name} logger-name: {log_name} config: {config}')
 
     return logger, config
 
 
-def _init_logger(name: str, log_ini_filename: str, ini_filename: str) -> logging.Logger:
+def _config_from_file(filename: str) -> tuple[Config]:
+    if filename.endswith('.toml'):
+        config = _config_from_toml_file(filename)
+        return config
+    elif filename.endswith('.ini'):
+        config = _config_from_ini_file(filename)
+        return config
+    else:
+        raise Exception(f'not supported file type: filename: {filename}')
+
+
+def _config_from_toml_file(filename: str) -> Config:
+    with open(filename, 'rb') as f:
+        return tomllib.load(f)
+
+
+def _init_logger(name: str, config: Config) -> logging.Logger:
     logger = logging.getLogger(name)
 
-    if not log_ini_filename:
-        log_ini_filename = ini_filename
+    logger_config = {section: val for section, val in config.items() if _is_valid_logger_section(section)}
 
-    if not log_ini_filename:
+    if 'loggers' not in logger_config and 'formatters' not in logger_config and 'handlers' not in logger_config:
         return logger
 
+    logger_configparser = RawConfigParser()
+    for section, val_by_section in logger_config.items():
+        logger_configparser[section] = val_by_section
+
+    # following logging.config.fileConfig default setting of disable_existing_loggers
+    #
+    disable_existing_loggers = _val_to_json(logger_config.get('loggers', {}).get('disable_existing_loggers', True))
+
     try:
-        logging.config.fileConfig(log_ini_filename, disable_existing_loggers=False)
-    except:
-        pass
+        logging.config.fileConfig(logger_configparser, disable_existing_loggers=disable_existing_loggers)
+    except Exception as e:
+        logging.warning(f'unable to setup logger: e: {e}')
 
     return logger
 
 
-def _init_ini_file(name: str, ini_filename: str, logger: logging.Logger) -> dict:
+def _init_config(name: str, config_from_file: Config) -> dict:
     '''
-    setup name:main config
+    setup config from config_from_file[name]
     '''
-    section_name = name + ':main'
-
-    config = _init_ini_file_core(ini_filename, section_name, logger)
-
-    return config
+    return config_from_file.get(name, {})
 
 
-def _init_ini_file_core(ini_filename: str, section_name: str, logger: logging.Logger) -> dict:
+def _config_from_ini_file(filename: str) -> dict[str, Any]:
     '''
     get ini conf from section
     return: config: {key: val} val: json_loaded
     '''
-    if not ini_filename:
+    if not filename:
         return {}
 
     config_parser = ConfigParser()
-    config_parser.read(ini_filename)
+    config_parser.read(filename)
     sections = config_parser.sections()
-    if section_name not in sections:
-        return {}
 
-    options = config_parser.options(section_name)
-    config = {option: _init_ini_file_parse_option(option, section_name, config_parser, logger) for option in options}
-
-    return config
+    return {section: _parse_options(config_parser, section) for section in sections}
 
 
-def _init_ini_file_parse_option(option: str, section_name: str, config_parser: ConfigParser, logger: logging.Logger) -> Any:
-    try:
-        val = config_parser.get(section_name, option)
-    except Exception as e:
-        logger.exception('unable to get option: section: %s option: %s e: %s', section_name, option, e)
-        val = ''
-    return _init_ini_file_val_to_json(option, val)
+def _parse_options(config_parser: ConfigParser, section: str) -> dict[str, Any]:
+    options = config_parser.options(section)
+    return {option: _parse_option(option, section, config_parser) for option in options}
 
 
-def _init_ini_file_val_to_json(option: str, val: Any) -> Any:
+def _parse_option(option: str, section: str, config_parser: ConfigParser) -> Any:
+    '''
+    '''
+    # special treatment to logger sections (get raw values)
+    if _is_valid_logger_section(section):
+        return config_parser.get(section, option, raw=True)
+
+    # json-formatted values for other sections.
+    val = config_parser.get(section, option)
+    return _val_to_json(val)
+
+
+def _val_to_json(val: Any) -> Any:
     '''
     try to do json load on value
     '''
 
-    if val.__class__.__name__ != 'str':
+    if not isinstance(val, str):
         return val
 
     orig_v = val
@@ -89,24 +224,42 @@ def _init_ini_file_val_to_json(option: str, val: Any) -> Any:
     except:
         val = orig_v
 
-    if option.endswith('_set'):
-        val = set(val)
-
     return val
 
 
-def _post_init_config(params: Optional[dict], config: dict, logger: logging.Logger) -> dict:
+def _is_valid_logger_section(section: str) -> bool:
+    if section in ['loggers', 'handlers', 'formatters']:
+        return True
+
+    if section.startswith('logger_'):
+        return True
+    if section.startswith('handler_'):
+        return True
+    if section.startswith('formatter_'):
+        return True
+
+    return False
+
+
+def _post_init_config(config: dict, extra_params: Optional[dict], is_extra_params_in_file_ok: bool, is_skip_extra_params_in_file: bool, logger: logging.Logger) -> dict:
     '''
     add additional parameters into config
     '''
 
-    if not params:
+    if not extra_params:
         return config
 
-    for (k, v) in params.items():
-        if k in config:
-            logger.warning('config will be overwritten by params: key: %s origin: %s new: %s', k, config[k], v)
+    # warning if not is_extra_in_file_ok
+    if not is_extra_params_in_file_ok:
+        for k, v in extra_params.items():
+            if k in config:
+                logger.warning('config will be overwritten by extras: key: %s origin: %s new: %s', k, config[k], v)
 
-    config.update(params)
+    # set valid extras, with is_skip_extra_in_file
+    valid_extras = extra_params
+    if is_skip_extra_params_in_file:
+        valid_extras = {k: v for k, v in extra_params if k not in config}
+
+    config.update(valid_extras)
 
     return config

--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -1,2 +1,2 @@
 cookiecutter==2.6.0
-pytest==8.2.1
+pytest==8.3.4

--- a/tests/data/test.toml
+++ b/tests/data/test.toml
@@ -1,0 +1,55 @@
+[test_cfg]
+
+a = 'b'
+test_ini = 'test2'
+test_list = [
+    'test0',
+    'test1',
+    2,
+]
+
+test_dict = {test_key = 'test_val', test_key2 = 'test_val2'}
+
+test_list_dict = [
+    {A = 1, B = 'b'},
+    {A = 2, B = 'c'},
+    {A = 3, B = 'd'},
+    {A = 4, B = 'e'},
+]
+
+[loggers]
+keys = 'root, temp'
+
+disable_existing_loggers = false
+
+[handlers]
+keys = 'console, file'
+
+[formatters]
+keys = 'generic'
+
+[logger_root]
+level    = 'WARNING'
+handlers = 'console'
+
+[logger_temp]
+level     = 'DEBUG'
+qualname  = 'test_cfg'
+handlers  = 'file, console'
+propagate = 0
+
+[handler_console]
+class     = 'StreamHandler'
+args      = '(sys.stderr,)'
+level     = 'NOTSET'
+formatter = 'generic'
+
+[handler_file]
+class     = 'FileHandler'
+args      = '''('log.tmp.test-from-toml.txt', 'w')'''
+level     = 'DEBUG'
+formatter = 'generic'
+
+[formatter_generic]
+format  = '%(asctime)s [%(levelname)-5.5s] %(module)s#%(funcName)s@%(lineno)d: %(message)s'
+datefmt = '%Y-%m-%d %H:%M:%S'

--- a/tests/data/test_no_disable_existing_loggers.ini
+++ b/tests/data/test_no_disable_existing_loggers.ini
@@ -9,6 +9,11 @@ test_list = [
 
 test_dict = {"test_key": "test_val", "test_key2": "test_val2"}
 
+test_set = [
+    "a",
+    "b",
+    "c"]
+
 test_list_dict = [
     {"A": 1, "B": "b"},
     {"A": 2, "B": "c"},
@@ -16,8 +21,7 @@ test_list_dict = [
     {"A": 4, "B": "e"}]
 
 [loggers]
-keys = root, temp
-disable_existing_loggers = false
+keys = root
 
 [handlers]
 keys = console
@@ -28,12 +32,6 @@ keys = generic
 [logger_root]
 level = WARNING
 handlers = console
-
-[logger_temp]
-level = DEBUG
-qualname = test_cfg
-handlers = console
-propagate = 0
 
 [handler_console]
 class = StreamHandler

--- a/tests/data/test_no_formatter.ini
+++ b/tests/data/test_no_formatter.ini
@@ -9,6 +9,11 @@ test_list = [
 
 test_dict = {"test_key": "test_val", "test_key2": "test_val2"}
 
+test_set = [
+    "a",
+    "b",
+    "c"]
+
 test_list_dict = [
     {"A": 1, "B": "b"},
     {"A": 2, "B": "c"},
@@ -16,31 +21,17 @@ test_list_dict = [
     {"A": 4, "B": "e"}]
 
 [loggers]
-keys = root, temp
+keys = root
 disable_existing_loggers = false
 
 [handlers]
 keys = console
 
-[formatters]
-keys = generic
-
 [logger_root]
-level = WARNING
-handlers = console
-
-[logger_temp]
 level = DEBUG
-qualname = test_cfg
 handlers = console
-propagate = 0
 
 [handler_console]
 class = StreamHandler
 args = (sys.stderr,)
 level = NOTSET
-formatter = generic
-
-[formatter_generic]
-format = %(asctime)s [%(levelname)-5.5s] %(module)s#%(funcName)s@%(lineno)d: %(message)s
-datefmt = %Y-%m-%d %H:%M:%S

--- a/tests/data/test_no_logger.ini
+++ b/tests/data/test_no_logger.ini
@@ -1,4 +1,4 @@
-[test_cfg:main]
+[test_cfg]
 
 a = b
 test_ini = test2

--- a/tests/data/test_no_show_config_because_setting_info_in_config.ini
+++ b/tests/data/test_no_show_config_because_setting_info_in_config.ini
@@ -9,6 +9,11 @@ test_list = [
 
 test_dict = {"test_key": "test_val", "test_key2": "test_val2"}
 
+test_set = [
+    "a",
+    "b",
+    "c"]
+
 test_list_dict = [
     {"A": 1, "B": "b"},
     {"A": 2, "B": "c"},
@@ -30,7 +35,7 @@ level = WARNING
 handlers = console
 
 [logger_temp]
-level = DEBUG
+level = INFO
 qualname = test_cfg
 handlers = console
 propagate = 0

--- a/tests/test_cfg.py
+++ b/tests/test_cfg.py
@@ -15,14 +15,13 @@ class TestCfg(unittest.TestCase):
         pass
 
     def test_init(self):
-        logger, config = cfg.init('test_cfg', 'tests/data/test.ini', params={'test_params': 'test'})
+        logger, config = cfg.init('test_cfg', 'tests/data/test.ini', extra_params={'test_params': 'test'}, show_config=logging.DEBUG)
 
         assert config['a'] == 'b'
         assert config['test_params'] == 'test'
         assert config['test_ini'] == 'test2'
         assert config['test_list'] == ['test0', 'test1', 2]
         assert config['test_dict'] == {'test_key': 'test_val', 'test_key2': 'test_val2'}
-        assert config['test_set'] == set(['a', 'b', 'c'])
         assert config['test_list_dict'] == [
             {'A': 1, 'B': 'b'},
             {'A': 2, 'B': 'c'},
@@ -30,18 +29,80 @@ class TestCfg(unittest.TestCase):
             {'A': 4, 'B': 'e'},
         ]
 
-    def test_init_no_logger(self):
-        logger, config = cfg.init('test_cfg', 'tests/data/test_no_logger.ini', params={'test_params': 'test'})
+    def test_ini_toml(self):
+        logger, config = cfg.init('test_cfg', 'tests/data/test.toml', extra_params={'test_params': 'test'}, show_config=logging.DEBUG)
 
         assert config['a'] == 'b'
         assert config['test_params'] == 'test'
         assert config['test_ini'] == 'test2'
         assert config['test_list'] == ['test0', 'test1', 2]
         assert config['test_dict'] == {'test_key': 'test_val', 'test_key2': 'test_val2'}
-        assert config['test_set'] == set(["a", "b", "c"])
+        assert config['test_list_dict'] == [
+            {'A': 1, 'B': 'b'},
+            {'A': 2, 'B': 'c'},
+            {'A': 3, 'B': 'd'},
+            {'A': 4, 'B': 'e'},
+        ]
+
+    def test_init_no_show_config_because_setting_info_in_config(self):
+        logger, config = cfg.init('test_cfg', 'tests/data/test_no_show_config_because_setting_info_in_config.ini', extra_params={'test_params': 'test'}, show_config=logging.DEBUG)
+
+        assert config['a'] == 'b'
+        assert config['test_params'] == 'test'
+        assert config['test_ini'] == 'test2'
+        assert config['test_list'] == ['test0', 'test1', 2]
+        assert config['test_dict'] == {'test_key': 'test_val', 'test_key2': 'test_val2'}
+        assert config['test_list_dict'] == [
+            {'A': 1, 'B': 'b'},
+            {'A': 2, 'B': 'c'},
+            {'A': 3, 'B': 'd'},
+            {'A': 4, 'B': 'e'},
+        ]
+
+    def test_init_no_disale_existing_loggers(self):
+        logger, config = cfg.init('test_cfg', 'tests/data/test_no_disable_existing_loggers.ini', extra_params={'test_params': 'test'})
+
+        assert config['a'] == 'b'
+        assert config['test_params'] == 'test'
+        assert config['test_ini'] == 'test2'
+        assert config['test_list'] == ['test0', 'test1', 2]
+        assert config['test_dict'] == {'test_key': 'test_val', 'test_key2': 'test_val2'}
+        assert config['test_list_dict'] == [
+            {'A': 1, 'B': 'b'},
+            {'A': 2, 'B': 'c'},
+            {'A': 3, 'B': 'd'},
+            {'A': 4, 'B': 'e'},
+        ]
 
     def test_init_none(self):
-        logger, config = cfg.init('test_cfg', 'tests/data/test_none.ini', params={'test_params': 'test'})
+        logger, config = cfg.init('test_cfg', 'tests/data/test_none.ini', extra_params={'test_params': 'test'})
 
         assert type(config) == dict
         assert config['test_params'] == 'test'
+
+    def test_init_no_logger(self):
+        logger, config = cfg.init('test_cfg', 'tests/data/test_no_logger.ini', extra_params={'test_params': 'test'})
+
+        assert config['a'] == 'b'
+        assert config['test_params'] == 'test'
+        assert config['test_ini'] == 'test2'
+        assert config['test_list'] == ['test0', 'test1', 2]
+        assert config['test_dict'] == {'test_key': 'test_val', 'test_key2': 'test_val2'}
+
+    def test_init_no_formatter(self):
+        logger, config = cfg.init('test_cfg', 'tests/data/test_no_formatter.ini', extra_params={'test_params': 'test'})
+
+        assert config['a'] == 'b'
+        assert config['test_params'] == 'test'
+        assert config['test_ini'] == 'test2'
+        assert config['test_list'] == ['test0', 'test1', 2]
+        assert config['test_dict'] == {'test_key': 'test_val', 'test_key2': 'test_val2'}
+
+    def test_init_not_is_extra_in_file_ok(self):
+        logger, config = cfg.init('test_cfg', 'tests/data/test.ini', extra_params={'test_list_dict': 'test'}, show_config=logging.DEBUG, is_extra_params_in_file_ok=False)
+
+        assert config['a'] == 'b'
+        assert config['test_ini'] == 'test2'
+        assert config['test_list'] == ['test0', 'test1', 2]
+        assert config['test_dict'] == {'test_key': 'test_val', 'test_key2': 'test_val2'}
+        assert config['test_list_dict'] == 'test'


### PR DESCRIPTION
configuration files:
1. remove `:main`
2. supporting both `.toml` and `.ini`
3. logging sections comply with `logging.fileConfig`
4. add `disable_existing_loggers` in `[loggers]` section

configuration code:
1. explicitly defining `Config` (inherited from `TypedDict`, cannot be used as instance).
2. change default of `disable_existing_loggers` as `True`.
3. add `is_extra_params_in_file_ok: bool = True` in `init` params
4. add `is_skip_extra_params_in_file: bool = False` in `init` params
5. add `show_config: Optional[int] = None` in `init` params

misc:
1. Reason not including .json: not a good file format for config.
2. Reason not including .yaml: not the standard lib from python.